### PR TITLE
Selenium standalone server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.kitchen/

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,19 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_zero
+
+platforms:
+  - name: ubuntu/xenial64  # 16.04
+  - name: ubuntu/trusty64  # 14.04
+  - name: centos/7         # 7
+  - name: centos/6         # 6
+  - name: debian/stretch64 # 9
+  - name: debian/jessie64  # 8
+
+suites:
+  - name: default
+    run_list:
+    attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,4 +16,5 @@ platforms:
 suites:
   - name: default
     run_list:
+      - recipe[cop_selenium::default]
     attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,7 +9,6 @@ platforms:
   - name: ubuntu/xenial64  # 16.04
   - name: ubuntu/trusty64  # 14.04
   - name: centos/7         # 7
-  - name: centos/6         # 6
   - name: debian/stretch64 # 9
   - name: debian/jessie64  # 8
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,4 @@
+default['selenium']['version'] = '3.4.0'
+default['selenium']['path']    = '/opt/selenium-server-standalone.jar'
+default['selenium']['owner']   = 'root'
+default['selenium']['group']   = 'root'

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,9 +2,9 @@ name 'cop_selenium'
 maintainer 'Copious Inc.'
 maintainer_email 'engineering@copiousinc.com'
 license 'MIT'
-description 'Installs and configures tools for testing.'
+description 'Installs and configures Selenium and dependencies.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.0.0'
+version '0.1.0'
 
 source_url 'https://github.com/copious-cookbooks/selenium'
 issues_url 'https://github.com/copious-cookbooks/selenium/issues'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,0 +1,15 @@
+name 'cop_selenium'
+maintainer 'Copious Inc.'
+maintainer_email 'engineering@copiousinc.com'
+license 'MIT'
+description 'Installs and configures tools for testing.'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version '0.0.0'
+
+source_url 'https://github.com/copious-cookbooks/selenium'
+issues_url 'https://github.com/copious-cookbooks/selenium/issues'
+
+supports 'ubuntu', '>= 14.04'
+supports 'debian', '>= 8'
+supports 'rhel', '>= 6'
+supports 'centos', '>= 6'

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,5 +11,5 @@ issues_url 'https://github.com/copious-cookbooks/selenium/issues'
 
 supports 'ubuntu', '>= 14.04'
 supports 'debian', '>= 8'
-supports 'rhel', '>= 6'
-supports 'centos', '>= 6'
+supports 'rhel', '>= 7'
+supports 'centos', '>= 7'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,0 +1,7 @@
+#
+# Cookbook Name:: cop_selenium
+# Recipe:: default
+# Author:: Copious Inc. <engineering@copiousinc.com>
+#
+
+include_recipe 'cop_selenium::dependencies'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,3 +5,4 @@
 #
 
 include_recipe 'cop_selenium::dependencies'
+include_recipe 'cop_selenium::install'

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -5,9 +5,16 @@
 #
 
 # Install OpenJDK
-pkg = value_for_platform_family(
-    rhel: 'java-1.8.0-openjdk',
-    debian: 'openjdk-8-jre'
-)
+case node['platform_family']
+when 'rhel'
+    pkg = 'java-1.8.0-openjdk'
+when 'debian'
+    case node['lsb']['codename']
+    when 'jessie', 'trusty'
+        pkg = 'openjdk-7-jre'
+    when 'stretch', 'xenial'
+        pkg = 'openjdk-8-jre'
+    end
+end
 
 package pkg

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -1,0 +1,13 @@
+#
+# Cookbook Name:: cop_selenium
+# Recipe:: dependencies
+# Author:: Copious Inc. <engineering@copiousinc.com>
+#
+
+# Install OpenJDK
+pkg = value_for_platform_family(
+    rhel: 'java-1.8.0-openjdk',
+    debian: 'openjdk-8-jre'
+)
+
+package pkg

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -1,0 +1,16 @@
+#
+# Cookbook Name:: cop_selenium
+# Recipe:: install
+# Author:: Copious Inc. <engineering@copiousinc.com>
+#
+
+full_version  = node['selenium']['version']
+short_version = full_version.to_f
+
+remote_file node['selenium']['path'] do
+    source "http://selenium-release.storage.googleapis.com/#{short_version}/selenium-server-standalone-#{full_version}.jar"
+    owner  node['selenium']['owner']
+    group  node['selenium']['group']
+    mode   '0755'
+    action :create
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,0 +1,4 @@
+require 'spec_helper'
+
+describe 'selenium::default' do
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,10 +1,16 @@
 require 'spec_helper'
 
+# Check which OS family the node belongs to (Red Hat, Debian)
 case os[:family]
-when 'debian', 'ubuntu'
-    pkg = 'openjdk-8-jre'
 when 'redhat'
     pkg = 'java-1.8.0-openjdk'
+when 'debian', 'ubuntu'
+    case os[:release].to_i # Drop OS release minor version (no decimal)
+    when 14, 8 # Ubuntu Trusty, Debian Jessie
+        pkg = 'openjdk-7-jre'
+    when 16, 9 # Ubuntu Xenial, Debian Stretch
+        pkg = 'openjdk-8-jre'
+    end
 end
 
 describe 'selenium::default' do

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -12,4 +12,10 @@ describe 'selenium::default' do
         it { should be_installed }
     end
 
+    describe file('/opt/selenium-server-standalone.jar') do
+        it { should exist }
+        it { should be_owned_by 'root' }
+        it { should be_grouped_into 'root' }
+        it { should be_mode '755' }
+    end
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,4 +1,15 @@
 require 'spec_helper'
 
+case os[:family]
+when 'debian', 'ubuntu'
+    pkg = 'openjdk-8-jre'
+when 'redhat'
+    pkg = 'java-1.8.0-openjdk'
+end
+
 describe 'selenium::default' do
+    describe package(pkg) do
+        it { should be_installed }
+    end
+
 end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,0 +1,5 @@
+require 'serverspec'
+
+set :backend, :exec
+
+set :path, '/sbin:/usr/local/sbin:/usr/sbin:$PATH'


### PR DESCRIPTION
* Installs OpenJDK 7 for Ubuntu Trusty and Debian Jessie
* Installs OpenJDK 8 for RHEL/CentOS 7+, Ubuntu Xenial, and Debian Stretch
* Installs Selenium standalone server, default to most recent version, 3.4.0

Kitchen tests pass on all platforms.